### PR TITLE
Si la membresía esta vencida, no sale el anuncio

### DIFF
--- a/neural/templates/index.html
+++ b/neural/templates/index.html
@@ -126,6 +126,9 @@
           {% endif %}
 
         });
+
+        var days_duration = {{ days_duration }};
+
         {% if days_duration > 0 %}
             var days_duration = {{ days_duration }};
             Swal.fire({
@@ -133,7 +136,7 @@
                 text: "te quedan " + days_duration + " días para seguir entrenando.",
                 type:"success"
             });
-        {% elif days_duration <= 0 %}
+        {% else %}
             Swal.fire({
                 title: 'Membresía vencida.',
                 text: "tu membresía ha vencido, contáctate con nosotros para renovarla",


### PR DESCRIPTION
Hola! Soy usuario con la membresia vencida y no me sale este anuncio. No conozco mucho del lenguaje entonces usé chatGPT para la solución y me dió lo siguiente:

<script>
    $(document).ready(function () {
        {% if not profile %}
        $("#myModal").modal('show');
        {% endif %}
    });

    var days_duration = {{ days_duration }};

    if (days_duration > 0) {
        Swal.fire({
            title: 'Membresía activa.',
            text: "Te quedan " + days_duration + " días para seguir entrenando.",
            type: "success"
        });
    } else {
        Swal.fire({
            title: 'Membresía vencida.',
            text: "Tu membresía ha vencido, contáctate con nosotros para renovarla",
            type: "warning"
        });
    }
</script>

<script>
    function handleLinkClick() {
        Swal.fire({
            title: 'Membresía vencida.',
            text: "Tu membresía ha vencido, contáctate con nosotros para renovarla",
            type: "warning"
        });
        return false;
    }
</script>
